### PR TITLE
WIP: Enable zodbsync, add example config and usage guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,54 @@ return 'will not work'
 **Attention!**
 Only allow packages you really need, avoid using too many fancy python packages
 in zope python sripts. Better write a short wrapper module providing the stuff
-you need, keep such magic away from the `data.fs` !
+you need, keep such magic away from the `Data.fs` !
+
+## zodbsync usage
+
+Zope environments installed using this repo also ship with a handy tool named
+`zodbsync`. After the installation you can use it create a filesystem representation
+of the `Data.fs` which can be read using `perfact-zoperecord` and written via
+`perfact-zopeplayback`.
+
+**Stop your running zope instance,** then setup `zodbsync_config.py`, most importantly:
+
+```python
+# Path of the Zope instance configuration to use to
+wsgi_conf_path = '/path/to/this/repo/app/instance/etc/wsgi.conf'
+
+# Path to Data.fs which is needed for lookup of object IDs from transaction IDs
+# with perfact-zoperecord --watch
+datafs_path = '/path/to/this/repo/app/instance/var/Data.fs'
+
+# Base directory of the repository
+base_dir = '/place/to/keep/such/repos'
+```
+
+Then activate the zope environment and call `perfact-zoperecord` using the altered
+configuration file:
+
+```bash
+cd /path/to/this/repo/app
+. bin/activate
+perfact-zoperecord -c ../zodbsync_config.py
+```
+
+This will read the `Data.fs` of your zope instance and throw its content to the
+`base_dir` folder previously configured.
+
+Now you can alter the files created in the `base_dir` folder, use `perfact-zopeplayback`
+to push files back into the `Data.fs`:
+
+```bash
+cd /path/to/this/repo/app
+. bin/activate
+cd /place/to/keep/such/repos   # base_dir !
+perfact-zopeplayback -c /path/to/this/repo/zodbsync_config.py /
+```
+
+For a more sophisticated usage use the `-h` argument to display further help on
+these tools. For even more infos on them visit [the git repo](https://github.com/perfact/zodbsync)
+
 
 # TODO
 * Pythonize the installers! Either via args or via input via Terminal

--- a/install.sh
+++ b/install.sh
@@ -66,16 +66,17 @@ echo "Install customized SimpleUserFolder"
 bin/pip install -e custom-products/SimpleUserFolder
 
 # NOTE: Maybe use -e flag to simplify on-the-fly changes.
-echo "Install customized ZPerFactMods"
+# echo "Install customized ZPerFactMods"
 # bin/pip install -e custom-products/ZPerFactMods
 
-echo "Install customized Products.PerFactErrors"
+# echo "Install customized Products.PerFactErrors"
 # bin/pip install -e custom-products/Products.PerFactErrors
 
 echo "Install zodbsync"
 # bin/pip install -e custom-products/perfact-zodbsync
+bin/pip install git+https://github.com/perfact/zodbsync
 
-echo "Recreating zeo and wsgiinstance"
+#echo "Recreating zeo and wsgiinstance"
 #bin/mkzeoinstance zeo 127.0.0.1:9011
 bin/mkwsgiinstance -d instance -u admin:admin
 rm -rf ../custom-products/

--- a/zodbsync_config.py
+++ b/zodbsync_config.py
@@ -1,0 +1,28 @@
+# Path of the Zope instance configuration to use to
+# instantiate Zope2.app()
+#conf_path = '/var/lib/zope2.13/instance/ema/etc/zope.conf'
+wsgi_conf_path = '/path/to/this/repo/app/instance/etc/wsgi.conf'
+
+# Path to Data.fs which is needed for lookup of object IDs from transaction IDs
+# with perfact-zoperecord --watch
+datafs_path = '/path/to/this/repo/app/instance/var/Data.fs'
+
+# user that is used to create commits and as default owner of objects
+manager_user = 'admin'
+
+# create the manager user on empty databases
+create_manager_user = False
+
+# sets the default owner for objects that have no owner in the file system representation
+default_owner = 'admin'
+
+# Base directory of the repository
+base_dir = '/place/to/keep/such/repos'
+
+# default settings for git repos
+commit_name = "Zope Developer"
+commit_email = "zope-devel@example.de"
+commit_message = "Generic commit message."
+
+# email address to send commit summaries of default commits to
+#codechange_mail = "zope-devel@example.de"


### PR DESCRIPTION
zodbsync works perfectly fine which is great news i think.

We can use it to solve the second part of the database connection issue. I successfully created and altered a database connector in zope using `perfact-zopeplayback`.

We may automate the creation of `zodbsync_config.py` in the future, this way we could initialize the zope repo directly after installation. Then we could use `EXTERNAL_ZOPE_DATA` to clone a zope repo from elsewhere and push it into our fresh `Data.fs`.

This would definitively make us the coolest and most modern Zope4 users on the planet :rocket: 